### PR TITLE
Trapped wraps context.Canceled

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -2,14 +2,24 @@ package graceful
 
 import (
 	"context"
-	"errors"
 	"os"
 	"os/signal"
 	"sync"
 )
 
 // Trapped is the error returned by Context.Err when the context is trapped.
-var Trapped = errors.New("context trapped")
+// It wraps context.Canceled.
+var Trapped = &trapped{}
+
+type trapped struct{}
+
+func (t *trapped) Error() string {
+	return "context trapped"
+}
+
+func (t *trapped) Unwrap() error {
+	return context.Canceled
+}
 
 // WithTrap returns a copy of parent with a new Done channel. The returned
 // context's Done channel is closed when the specified signal is trapped

--- a/graceful_test.go
+++ b/graceful_test.go
@@ -1,0 +1,66 @@
+package graceful_test
+
+import (
+	"context"
+	"errors"
+	"syscall"
+	"testing"
+
+	"github.com/closer/graceful"
+)
+
+func TestGracefulWithTrapping(t *testing.T) {
+	ctx := graceful.WithTrap(context.Background(), syscall.SIGINT)
+
+	// send signal
+	_ = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+
+	<-ctx.Done()
+	err := ctx.Err()
+
+	if !errors.Is(err, graceful.Trapped) {
+		t.Errorf("expected graceful.Trapped but given %v", err)
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled but given %v", err)
+	}
+}
+
+func TestGracefulWithCanceledChildContext(t *testing.T) {
+	ctx := graceful.WithTrap(context.Background(), syscall.SIGINT)
+	ctx, cancel := context.WithCancel(ctx)
+
+	// cancel child context
+	cancel()
+
+	<-ctx.Done()
+	err := ctx.Err()
+
+	if errors.Is(err, graceful.Trapped) {
+		t.Errorf("expected graceful.Trapped but given %v", err)
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled but given %v", err)
+	}
+}
+
+func TestGracefulWithCanceledParentContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = graceful.WithTrap(ctx, syscall.SIGINT)
+
+	// cancel parant context
+	cancel()
+
+	<-ctx.Done()
+	err := ctx.Err()
+
+	if errors.Is(err, graceful.Trapped) {
+		t.Errorf("expected graceful.Trapped but given %v", err)
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled but given %v", err)
+	}
+}


### PR DESCRIPTION
before
```go
err := someProcess(ctx)
if err != nil {
  if errors.Is(err, context.Canceled) || errors.Is(err, graceful.Trapped) {
    return nil
  }
  // error handling
}
```

after
```go
err := someProcess(ctx)
if err != nil {
  if errors.Is(err, context.Canceled) {
    return nil
  }
  // error handling
}
```